### PR TITLE
feat: レコメンド生成機能(OpenAI API使用)の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem 'pry-rails'
 gem 'rspotify'
 gem 'dotenv-rails'
 
+gem 'ruby-openai'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,11 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
+    event_stream_parser (1.0.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (3.1.0)
       net-http
     globalid (1.2.1)
@@ -155,6 +158,7 @@ GEM
     minitest (5.22.2)
     msgpack (1.7.2)
     multi_xml (0.6.0)
+    multipart-post (2.4.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
@@ -265,6 +269,10 @@ GEM
       addressable (~> 2.8.0)
       omniauth-oauth2 (>= 1.6)
       rest-client (~> 2.0.2)
+    ruby-openai (6.3.1)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.17.0)
@@ -333,6 +341,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3)
   rspotify
+  ruby-openai
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,23 @@ class ApplicationController < ActionController::Base
 	require 'rspotify'
   RSpotify.authenticate(ENV['SPOTIFY_CLIENT_ID'], ENV['SPOTIFY_SECRET_ID'])
 	ENV['ACCEPT_LANGUAGE'] = 'ja'
+
+	require 'openai'
+
+	def get_recommend_genre(genres)
+		client = OpenAI::Client.new(access_token: ENV['OPENAI_CLIENT_ID'])
+		response = client.chat(
+			parameters: {
+				model: 'gpt-3.5-turbo',
+				messages: [
+					{
+						role: 'user',
+						content: "あなたは幅広いジャンルを扱う音楽レコメンダーAIです。以下の配列はあるユーザーが好む音楽ジャンル郡です。この配列に含まれる音楽ジャンルの粒度とBPMとダイナミクスの傾向を考慮した上で、この配列に含まれるジャンルと関係性の薄いポピュラー音楽ジャンル、つまりこのユーザーが未だ聞いたことのないポピュラー音楽ジャンルを1つだけ推測し、1〜２単語の英単語で文字列として出力してください。ただしマイナー過ぎるジャンルとメジャー過ぎるジャンルはどちらも出力しないでください。 #{genres}"
+					}
+				]
+			}
+		)
+		response.dig('choices', 0, 'message', 'content')
+	end
+
 end

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -1,12 +1,28 @@
 class SongsController < ApplicationController
   include ApplicationHelper
 
+  before_action :set_list
+
   def show
-    @list = List.find(params[:list_id])
     @unique_genres = get_unique_genre_names(@list)
-    embed_url = RSpotify::Playlist.search(@unique_genres.first).first.tracks.first.embed
+    @recommend_genre = get_recommend_genre(@unique_genres)
+    searched_playlists = RSpotify::Playlist.search(@recommend_genre)
+
+    if searched_playlists.empty?
+			flash[:info] = 'レコメンドの生成に失敗しました'
+			redirect_to @list
+			return
+		end
+
+    embed_url = searched_playlists.first(4).max_by { |playlist| playlist.followers['total'] }.tracks.sample.embed
     url = embed_url.match(/https:\/\/embed\.spotify\.com\/\?uri=spotify:track:(\w+)/)
     @song = "https://open.spotify.com/embed/track/#{url[1]}"
   end
+
+  private
+
+	def set_list
+		@list = List.find(params[:list_id])
+	end
 
 end

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -2,4 +2,5 @@
 src="<%= @song %>"  
 width="50%" height="300" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
 <%= @unique_genres %>
-
+<%= @recommend_genre %>
+<%#	おすすめのジャンル名もひょうじすること、 あなたへのおすすめはこれ、みたいな、その下に再生画面をつくる%>


### PR DESCRIPTION
## 変更の概要

* レコメンド機能をOpenAI APIを使ったものに変更

## 変更内容

* gem ruby-openaiの導入
* レコメンドに使うジャンルの取得をOpenAIのAPIを使って定義したメソッドに変更

##その他

* RSpotifyの使用時に発生しうるエラーのハンドリングを各コントローラーに追加