### PR TITLE
リスト内ジャンル内の一覧表示機能

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,4 +1,6 @@
 class ListsController < ApplicationController
+  include ApplicationHelper
+
   before_action :require_login
 
 	def index
@@ -10,6 +12,7 @@ class ListsController < ApplicationController
     session[:visited] = nil
     @list = List.find(params[:id])    
     @artists = @list.artists.order(created_at: :desc)
+    @unique_genres = get_unique_genre_names(@list)
   end
 
 	def new

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -9,16 +9,7 @@ window.Stimulus   = application
 
 export { application }
 
-document.getElementById('RecommendButton').addEventListener('click', function() {
-    this.outerHTML = `
-      <div class="flex justify-center" aria-label="Loading">
-        <div class="animate-ping h-2 w-2 bg-blue-500 rounded-full"></div>
-        <div class="animate-ping h-2 w-2 bg-purple-500 rounded-full mx-4"></div>
-        <div class="animate-ping h-2 w-2 bg-rose-500 rounded-full"></div>
-      </div>
-    `;
-  });
-
+//リストにアーティストを追加するための検索サジェストのドロップダウン機能
 // 検索サジェスト用の、turbo:loadが発生したとき（ページが読み込まれたとき）に実行する関数として設定
 document.addEventListener('turbo:load', function() {
   var inputElement = document.getElementById('artist-name-input');
@@ -62,12 +53,26 @@ document.addEventListener('turbo:load', function() {
           console.error('There has been a problem with your fetch operation:', error);
         });
     });
-
     // ドロップダウンリスト以外の場所をクリックしたときにリストを非表示にする
     document.addEventListener('click', function(e) {
-      if (!e.target.closest('#artist-dropdown')) {
-        document.getElementById('artist-dropdown-list').classList.add('hidden');
+      var dropdownList = document.getElementById('artist-dropdown-list');
+      if (dropdownList && !e.target.closest('#artist-dropdown')) {
+        dropdownList.classList.add('hidden');
       }
     });
   }
 });
+
+//レコメンドボタンをクリックしたときのローディングアニメーション
+let recommendButton = document.getElementById('RecommendButton');
+if (recommendButton) {
+  recommendButton.addEventListener('click', function() {
+    this.outerHTML = `
+      <div class="flex justify-center" aria-label="Loading">
+        <div class="animate-ping h-2 w-2 bg-blue-500 rounded-full"></div>
+        <div class="animate-ping h-2 w-2 bg-purple-500 rounded-full mx-4"></div>
+        <div class="animate-ping h-2 w-2 bg-rose-500 rounded-full"></div>
+      </div>
+    `;
+  });
+}

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -66,6 +66,17 @@
 	</div>
 </div>
 
+<div class="container mx-auto my-4 px-2">
+  <div class="bg-gradient-to-r from-purple-900 to-indigo-800 text-white rounded-lg shadow-lg p-4">
+    <h2 class="text-xl text-gray-300 font-bold mb-4"><i class="fa-solid fa-circle-exclamation"></i> 現在このリストに含まれるジャンル:</h2>
+    <div class="flex flex-wrap">
+      <% @unique_genres.sort.each do |genre| %>
+        <span class="bg-indigo-600 text-white px-3 py-1 rounded-full text-sm mr-2 mb-2"><%= genre.titleize %></span>
+      <% end %>
+    </div>
+  </div>
+</div>
+
 <div class="container item-center mx-auto py-4 px-8 flex flex-col justify-center max-w-md">
 	<%= image_tag 'icon_big.jpg', alt: 'Icon', class: 'animate-pulse btn btn-ghost shadow-lg rounded-full object-cover h-full' %>
 </div>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -28,9 +28,9 @@
       <div class="flex flex-col">
         <%= form.label :name, "アーティスト名", class: "font-bold text-lg mb-2" %>
         <%= form.text_field :name, id: 'artist-name-input', list: 'artist-datalist', class: "text-black border-2 border-gray-300 p-2 rounded-md", placeholder: "Artist Name" %>
-<div id="artist-dropdown" class="relative">
-  <div id="artist-dropdown-list" class="absolute w-full text-amber-100 bg-gradient-to-r from-slate-500 to-slate-400 border border-gray-300 rounded-md overflow-auto max-h-60 hidden"></div>
-</div>
+        <div id="artist-dropdown" class="relative">
+          <div id="artist-dropdown-list" class="absolute w-full text-amber-600 bg-opacity-90 bg-slate-900 border border-gray-300 rounded-md overflow-auto max-h-60 hidden"></div>
+        </div>
         <p class="py-2 text-xs text-amber-300">入力した名前に最も近いアーティストが取得されます</p>
       </div>
       <%= form.submit "このアーティストをリストに追加", class: "btn btn-accent btn-outline text-xl text-white p-2 rounded-md" %>


### PR DESCRIPTION
## 変更の概要

* リスト詳細画面でジャンル一覧を表示した

## 変更内容

* コントローラーでは、該当アクションでユニークにジャンルを取得するメソッドを使用
* また、上記のためにヘルパーを読み込ませる設定を追加

* ビューでは、画面下部にジャンルの表示部分を追加

## 備考

* レコメンドのローディングアニメーションに関するJavaScriptの修正を行った